### PR TITLE
Add CONFLICT and REQUEST_TIMEOUT handler error types

### DIFF
--- a/src/NexusRpc/Handlers/HandlerErrorType.cs
+++ b/src/NexusRpc/Handlers/HandlerErrorType.cs
@@ -35,6 +35,19 @@ namespace NexusRpc.Handlers
         NotFound,
 
         /// <summary>
+        /// Returned by the server to when it has given up handling a request. The may occur by enforcing a client
+        /// provided `Request-Timeout` or for any arbitrary reason such as enforcing some configurable limit. Subsequent
+        /// requests by the client are permissible.
+        /// </summary>
+        RequestTimeout,
+
+        /// <summary>
+        /// The request could not be made due to a conflict. The may happen when trying to create an operation that
+        /// has already been started. Clients should not retry this request unless advised otherwise.
+        /// </summary>
+        Conflict,
+
+        /// <summary>
         /// Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file
         /// system is out of space. Subsequent requests by the client are permissible.
         /// </summary>

--- a/src/NexusRpc/Handlers/HandlerException.cs
+++ b/src/NexusRpc/Handlers/HandlerException.cs
@@ -16,6 +16,8 @@ namespace NexusRpc.Handlers
             ["UNAUTHENTICATED"] = HandlerErrorType.Unauthenticated,
             ["UNAUTHORIZED"] = HandlerErrorType.Unauthorized,
             ["NOT_FOUND"] = HandlerErrorType.NotFound,
+            ["REQUEST_TIMEOUT"] = HandlerErrorType.RequestTimeout,
+            ["CONFLICT"] = HandlerErrorType.Conflict,
             ["RESOURCE_EXHAUSTED"] = HandlerErrorType.ResourceExhausted,
             ["INTERNAL"] = HandlerErrorType.Internal,
             ["NOT_IMPLEMENTED"] = HandlerErrorType.NotImplemented,
@@ -32,6 +34,7 @@ namespace NexusRpc.Handlers
                 HandlerErrorType.Unauthenticated,
                 HandlerErrorType.Unauthorized,
                 HandlerErrorType.NotFound,
+                HandlerErrorType.Conflict,
                 HandlerErrorType.NotImplemented,
             };
 


### PR DESCRIPTION
## Description

Add the `CONFLICT` and `REQUEST_TIMEOUT` handler error types.

## Changes

- Added `RequestTimeout` and `Conflict` enum values to `HandlerErrorType`
- Set `Conflict` as non-retryable by default,  `RequestTimeout` as retryable by default.

Fixes #9